### PR TITLE
removing icon to avoid manifest merger conflicts

### DIFF
--- a/simple-tag-imageview/src/main/AndroidManifest.xml
+++ b/simple-tag-imageview/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="wujingchao.net.mylibrary">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher">
+    <application android:allowBackup="true" android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
I added this library to my project and immediately got a manifest merger failure because my project and the library specify different application icon names.  I don't believe there's a reason for the library to specify an icon.